### PR TITLE
[doc] Fix EarlGrey and CW340 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Symphony system
 
 Symphony is a system for evaluating the usage of [CHERIoT Ibex core](https://github.com/microsoft/cheriot-ibex) as a microcontroller for embedded, IoT and Operational Technology applications that require the use of a root of trust
-The system is an integration of a [Sonata system](https://github.com/lowRISC/sonata-system) (containing a [CHERIoT Ibex core](https://github.com/microsoft/cheriot-ibex)) with [OpenTitan Earl Grey](https://github.com/lowRISC/opentitan)
-It is designed for use on FPGA and specifically targets the [Sonata FPGA board](./doc/architecture/board.md).
+The system is an integration of a [Sonata system](https://github.com/lowRISC/sonata-system) (containing a [CHERIoT Ibex core](https://github.com/microsoft/cheriot-ibex)) with [OpenTitan Earl Grey](https://opentitan.org/book/hw/top_earlgrey/doc/datasheet.html).
+It is designed for use on FPGA and specifically targets the [NewAE CW340](https://media.newae.com/datasheets/NAE-CW340-OTKIT_datasheet.pdf).
 
 The system is at its architectural definition and specification stage.
 RTL development has yet to begin.
-In the meantime, please read the [architecture specfication](./doc/architecture/intro.md).
+In the meantime, please read the [architecture specfication](./doc/architecture.md).
 
 Symphony is part of the [Sunburst Project](https://www.sunburst-project.org) funded by [UKRI](https://www.ukri.org/) / [DSbD](https://www.dsbd.tech/).
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -10,7 +10,7 @@ In particular whilst due consideration will be given towards security hardening 
 
 The Symphony architecture comprises a number of components:
 - FPGA configuration architecture:
-  What changes do we make to [Sonata](https://github.com/lowRISC/sonata-system), what changes to we make to [OpenTitan Earl Grey](https://github.com/lowRISC/opentitan) and how do we connect the two together?
+  What changes do we make to [Sonata](https://github.com/lowRISC/sonata-system), what changes to we make to [OpenTitan Earl Grey](https://opentitan.org/book/hw/top_earlgrey/doc/datasheet.html) and how do we connect the two together?
   It defines everything we are using a hardware description language for.
 - Software architecture:
   How do we compose Earl Grey and Sonata together?


### PR DESCRIPTION
Better to link to the EarlGrey datasheet rather than the top-level OpenTitan repository so you can directly see what's in EarlGrey specifically.

The README incorrectly linked to the Sonata FPGA board (copy/paste error) rather than the CW340.